### PR TITLE
Stop prim_dot_general documenting the nv_* layer's semantics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@
   functions was improved.
 * `jit_eval()` was removed as it is no longer needed.
 
+## Bug fixes
+
+* `?prim_dot_general` no longer claims that its operands are promoted to a
+  common data type and that scalars are broadcast. It did neither -- it used
+  the documentation template written for the `nv_*` layer.
+
 ## Tests
 
 * Moved some of pjrt's dispatcher tests into anvl.

--- a/R/primitives.R
+++ b/R/primitives.R
@@ -252,7 +252,12 @@ prim_broadcast_in_axes <- new_primitive(
 #' @description
 #' General dot product of two arrays, supporting contraction over arbitrary
 #' axes and batching.
-#' @template params_lhs_rhs
+#' @param lhs,rhs ([`arrayish`])\cr
+#'   Left and right operand. Both must reach one data type: an R value takes
+#'   the other operand's, within its own category, and two operands that
+#'   already have a data type must agree -- neither is widened to meet the
+#'   other. Their shapes are constrained by `contracting_axes` and
+#'   `batching_axes` rather than having to match.
 #' @param contracting_axes (`list(integer(), integer())`)\cr
 #'   A list of two integer vectors specifying which axes of `lhs` and
 #'   `rhs` to contract over. The contracted axes must have matching sizes.

--- a/man/prim_dot_general.Rd
+++ b/man/prim_dot_general.Rd
@@ -14,9 +14,11 @@ prim_dot_general(
 }
 \arguments{
 \item{lhs, rhs}{(\code{\link{arrayish}})\cr
-Left and right operand.
-Operands are \link[=nv_promote_to_common]{promoted to a common data type}.
-Scalars are \link[=nv_broadcast_scalars]{broadcast} to the shape of the other operand.}
+Left and right operand. Both must reach one data type: an R value takes
+the other operand's, within its own category, and two operands that
+already have a data type must agree -- neither is widened to meet the
+other. Their shapes are constrained by \code{contracting_axes} and
+\code{batching_axes} rather than having to match.}
 
 \item{contracting_axes}{(\code{list(integer(), integer())})\cr
 A list of two integer vectors specifying which axes of \code{lhs} and


### PR DESCRIPTION
It used `@template params_lhs_rhs`, the template written for the `nv_*` functions, so `?prim_dot_general` told readers that "Operands are promoted to a common data type" and "Scalars are broadcast to the shape of the other operand". The primitive does neither: it promotes with `promote_rdata_common()`, which never widens an operand that already has a data type, and primitives do not broadcast at all.

It was the only primitive using that template. The operand documentation is now written out, including the shape rule, which for a contraction is not "must match" either.