### PR TITLE
Check operand data types in triangular_solve and convolution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,14 @@
   functions was improved.
 * `jit_eval()` was removed as it is no longer needed.
 
+## Bug fixes
+
+* `prim_triangular_solve()` now rejects a non-float operand, and
+  `prim_convolution()` a boolean one, when the call is traced. Both used to
+  reach the backend and fail with a raw MLIR dump; the other linear-algebra
+  primitives (`prim_qr()`, `prim_lu()`, `prim_svd()`, `prim_eigh()`) already
+  checked. Integer convolution, which the backend does support, is unaffected.
+
 ## Tests
 
 * Moved some of pjrt's dispatcher tests into anvl.

--- a/R/asserts.R
+++ b/R/asserts.R
@@ -124,6 +124,42 @@ assert_float_dtype <- function(x, arg = rlang::caller_arg(x), hint = NULL) {
   dt
 }
 
+# The float-only half of `assert_linalg_matrix()`, for operations that
+# constrain the data type but not the shape. Without it an integer operand
+# reaches the backend and fails with a raw MLIR dump.
+assert_float_operand <- function(x, arg) {
+  dt <- peek_dtype(to_abstract(x))
+  if (is_dtype_float(dt)) {
+    return(invisible(NULL))
+  }
+  cli_abort(
+    c(
+      "{.arg {arg}} must have a floating-point dtype.",
+      "x" = "Got dtype {.val {as.character(dt)}}.",
+      "i" = "Convert it with {.fn nv_convert}."
+    ),
+    call = NULL
+  )
+}
+
+# The backend has no convolution over booleans -- it answers `Unsupported type:
+# pred` -- while integers and floats both work, so this is narrower than
+# `assert_float_operand()`.
+assert_numeric_operand <- function(x, arg) {
+  dt <- peek_dtype(to_abstract(x))
+  if (!is_dtype_bool(dt)) {
+    return(invisible(NULL))
+  }
+  cli_abort(
+    c(
+      "{.arg {arg}} must have an integer or floating-point dtype.",
+      "x" = "Got dtype {.val {as.character(dt)}}.",
+      "i" = "Convert it with {.fn nv_convert}."
+    ),
+    call = NULL
+  )
+}
+
 assert_linalg_matrix <- function(x, arg, square = FALSE) {
   s <- shape(x)
   if (length(s) != 2L) {

--- a/R/primitives.R
+++ b/R/primitives.R
@@ -3303,6 +3303,8 @@ prim_triangular_solve <- new_primitive(
       list(out)
     }
     operands <- apply_promotion(list(a = a, b = b), promote_rdata_common())
+    assert_float_operand(operands$a, "a")
+    assert_float_operand(operands$b, "b")
     graph_desc_add(
       self,
       operands,
@@ -3622,6 +3624,8 @@ prim_convolution <- new_primitive(
       list(vt2at(out))
     }
     operands <- apply_promotion(list(x = x, kernel = kernel), promote_rdata_common())
+    assert_numeric_operand(operands$x, "x")
+    assert_numeric_operand(operands$kernel, "kernel")
     graph_desc_add(
       self,
       operands,

--- a/tests/testthat/test-primitives-stablehlo.R
+++ b/tests/testthat/test-primitives-stablehlo.R
@@ -1214,3 +1214,38 @@ test_that("nv_matmul exposes precision and defaults to highest", {
 if (nzchar(system.file(package = "torch"))) {
   source(system.file("extra-tests", "test-primitives-stablehlo-torch.R", package = "anvl"), local = TRUE)
 }
+
+describe("data type checks on prim_triangular_solve and prim_convolution", {
+  it("rejects a non-float triangular solve at trace time", {
+    a <- nv_array(matrix(c(2L, 0L, 1L, 3L), nrow = 2))
+    b <- nv_array(matrix(c(4L, 3L), nrow = 2))
+    expect_error(
+      prim_triangular_solve(a, b, TRUE, TRUE, FALSE, FALSE),
+      "`a` must have a floating-point dtype"
+    )
+  })
+
+  it("still solves a float triangular system", {
+    a <- nv_array(matrix(c(2, 0, 1, 3), nrow = 2), dtype = "f32")
+    b <- nv_array(matrix(c(4, 3), nrow = 2), dtype = "f32")
+    expect_equal(as.numeric(prim_triangular_solve(a, b, TRUE, TRUE, FALSE, FALSE)), c(2, 1))
+  })
+
+  it("rejects a boolean convolution, which the backend cannot lower", {
+    expect_error(
+      nv_conv1d(nv_array(array(TRUE, c(1, 1, 4))), nv_array(array(TRUE, c(1, 1, 2)))),
+      "`x` must have an integer or floating-point dtype"
+    )
+  })
+
+  it("leaves integer and float convolution working", {
+    expect_equal(as.numeric(nv_conv1d(nv_array(array(1L, c(1, 1, 4))), nv_array(array(1L, c(1, 1, 2))))), c(2, 2, 2))
+    expect_equal(
+      as.numeric(nv_conv1d(
+        nv_array(array(1, c(1, 1, 4)), dtype = "f32"),
+        nv_array(array(1, c(1, 1, 2)), dtype = "f32")
+      )),
+      c(2, 2, 2)
+    )
+  })
+})


### PR DESCRIPTION
`prim_qr()`, `prim_lu()`, `prim_svd()` and `prim_eigh()` all reject a non-float operand at trace time via `assert_linalg_matrix()`. `prim_triangular_solve()` and `prim_convolution()` did not, so an unsupported data type reached the backend: an integer triangular solve produced a raw MLIR dump, and a boolean convolution a bare `Unsupported type: pred`.

Two asserts, matched to what each operation actually supports rather than to one blanket rule: `assert_float_operand()` for the triangular solve, whose spec is floating-point or complex, and `assert_numeric_operand()` for convolution, which the backend runs over integers perfectly well and only refuses for booleans. Integer convolution keeps working.


Claude-Session: https://claude.ai/code/session_01NCxqfqAhCCd17ygJeJm8YA