### PR TITLE
Check what prim_scatter's update_computation returns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,13 @@
   functions was improved.
 * `jit_eval()` was removed as it is no longer needed.
 
+## Bug fixes
+
+* `prim_scatter()` now checks that `update_computation` returns one value of
+  `x`'s data type, as `prim_reduce()` already did for its `reductor`. A
+  combiner returning something else made type inference declare a data type
+  the call could not produce, and failed in the backend.
+
 ## Tests
 
 * Moved some of pjrt's dispatcher tests into anvl.

--- a/R/primitives.R
+++ b/R/primitives.R
@@ -2973,6 +2973,23 @@ prim_scatter <- new_primitive(
 
     update_computation_graph <- trace_fn(update_computation, dummy_args, desc = desc_update, mode = "subgraph")
 
+    # As `prim_reduce()` does for its reductor: the scattered element is what
+    # `update_computation` returns, so a different data type there makes the
+    # inferred output type a lie and the call fails in the backend instead.
+    if (length(update_computation_graph$outputs) != 1L) {
+      cli_abort(c(
+        "{.arg update_computation} must return exactly one value.",
+        x = "Got {length(update_computation_graph$outputs)} outputs."
+      ))
+    }
+    update_out_dtype <- update_computation_graph$outputs[[1L]]$aval$dtype
+    if (update_out_dtype != x_dtype) {
+      cli_abort(c(
+        "{.arg update_computation} must return a value with the same data type as {.arg x}.",
+        x = "{.arg x} is {.val {as.character(x_dtype)}} and {.arg update_computation} returns {.val {as.character(update_out_dtype)}}." # nolint
+      ))
+    }
+
     # Register constants from the update computation graph
     register_consts(current_desc, update_computation_graph$constants)
 

--- a/tests/testthat/test-primitives-stablehlo.R
+++ b/tests/testthat/test-primitives-stablehlo.R
@@ -1214,3 +1214,38 @@ test_that("nv_matmul exposes precision and defaults to highest", {
 if (nzchar(system.file(package = "torch"))) {
   source(system.file("extra-tests", "test-primitives-stablehlo-torch.R", package = "anvl"), local = TRUE)
 }
+
+describe("prim_scatter update_computation", {
+  scatter_with <- function(update_computation) {
+    prim_scatter(
+      nv_array(c(0, 0, 0), dtype = "f64"),
+      nv_array(matrix(c(1L, 3L), ncol = 1)),
+      nv_array(c(10, 30), dtype = "f64"),
+      update_window_axes = integer(0),
+      inserted_window_axes = 1L,
+      x_batching_axes = integer(0),
+      scatter_indices_batching_axes = integer(0),
+      scatter_axes_to_x_axes = 1L,
+      index_vector_axis = 2L,
+      update_computation = update_computation
+    )
+  }
+
+  it("scatters with the default and with a combiner", {
+    expect_equal(as.numeric(scatter_with(NULL)), c(10, 0, 30))
+    expect_equal(as.numeric(scatter_with(function(old, new) prim_add(old, new))), c(10, 0, 30))
+  })
+
+  it("rejects a combiner that returns another data type", {
+    # Type inference took the operand's data type for the result, so a
+    # combiner returning something else made the inferred type a lie.
+    expect_error(
+      scatter_with(function(old, new) prim_convert(new, "f32")),
+      "`update_computation` must return a value with the same data type as `x`"
+    )
+    expect_error(
+      scatter_with(function(old, new) prim_gt(new, old)),
+      "`update_computation` returns \"bool\""
+    )
+  })
+})


### PR DESCRIPTION
The scattered element is whatever `update_computation` returns, but nothing checked its data type, so type inference went on declaring `x`'s. A combiner returning an `f32` for an `f64` operand made the inferred output type a lie and the call failed in the backend.

`prim_reduce()` already made exactly this check on its `reductor`; this is the same check on the same footing.


Claude-Session: https://claude.ai/code/session_01NCxqfqAhCCd17ygJeJm8YA