### PR TITLE
Check and promote the index operands of the slicing primitives

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,16 @@
   functions was improved.
 * `jit_eval()` was removed as it is no longer needed.
 
+## Bug fixes
+
+* The index operands of `prim_dynamic_slice()`, `prim_dynamic_update_slice()`,
+  `prim_gather()` and `prim_scatter()` are now checked when the call is traced
+  instead of failing in the lowering with a raw MLIR message. A non-integer
+  index (an R `1` rather than `1L`) is rejected by name, and the several start
+  indices of a dynamic slice are brought to one data type, as StableHLO
+  requires -- previously mixing an `i64` index with an `i32` one produced
+  `error: start indices must have same element type`.
+
 ## Tests
 
 * Moved some of pjrt's dispatcher tests into anvl.

--- a/R/primitives.R
+++ b/R/primitives.R
@@ -559,10 +559,8 @@ prim_static_slice <- new_primitive(
 #' time and you need stride support.
 #' @template param_prim_x_any
 #' @param ... ([`arrayish`] of integer type)\cr
-#'   Scalar start indices, one per axis of `x`. All must reach one integer
-#'   data type: an R value is written as an integer (`1L`) and takes the data
-#'   type of the indices it meets, and indices that already have one must
-#'   agree. They never take `x`'s data type.
+#'   Scalar start indices, one per axis of `x`.
+#'   Must all have the same integer data type, which R values are materialized at.
 #' @param slice_sizes (`integer()`)\cr
 #'   Size of the slice in each axis. Must have length equal to
 #'   `naxes(x)` and satisfy `1 <= slice_sizes <= nv_shape(x)`

--- a/R/primitives.R
+++ b/R/primitives.R
@@ -26,6 +26,44 @@ make_unary_op <- function(stablehlo_infer) {
 }
 
 
+# Index operands are consumed as integers by every backend. Without a check
+# here an R double among them commits to its `f32` default and the call fails
+# with a raw MLIR type error naming an operand number rather than an argument.
+assert_index_dtype <- function(x, arg) {
+  aval <- to_abstract(x)
+  dt <- peek_dtype(aval)
+  if (is_dtype_int(dt) || is_dtype_uint(dt)) {
+    return(invisible(NULL))
+  }
+  cli_abort(
+    c(
+      "{.arg {arg}} must be an index of integer data type.",
+      x = "Got {.val {as.character(dt)}}.",
+      i = if (is_rdata(aval)) {
+        "Write it as an R integer, e.g. {.code 1L} rather than {.code 1}."
+      } else {
+        "Convert it with {.fn nv_convert}."
+      }
+    ),
+    call = NULL
+  )
+}
+
+# The start indices of a dynamic slice must share one data type -- StableHLO
+# requires it -- so a bare `1L` yields to an `i64` sibling rather than
+# committing to its own default and failing in the lowering.
+promote_start_indices <- function(indices) {
+  # Named only for the messages -- both this check and `promote_rdata_common()`
+  # report against an argument, and the graph keeps them positional.
+  names(indices) <- sprintf("start index %d", seq_along(indices))
+  # Checked before promoting, while an R value still says it is one: afterwards
+  # it has been built at its default and there is no literal left to point at.
+  for (i in seq_along(indices)) {
+    assert_index_dtype(indices[[i]], names(indices)[[i]])
+  }
+  unname(apply_promotion(indices, promote_rdata_common()))
+}
+
 infer_reduce <- function(x, axes, drop) {
   old_shape <- shape(x)
   if (drop) {
@@ -521,8 +559,10 @@ prim_static_slice <- new_primitive(
 #' time and you need stride support.
 #' @template param_prim_x_any
 #' @param ... ([`arrayish`] of integer type)\cr
-#'   Scalar start indices, one per axis. Each must be a
-#'   scalar array. Pass one scalar per axis of `x`.
+#'   Scalar start indices, one per axis of `x`. All must reach one integer
+#'   data type: an R value is written as an integer (`1L`) and takes the data
+#'   type of the indices it meets, and indices that already have one must
+#'   agree. They never take `x`'s data type.
 #' @param slice_sizes (`integer()`)\cr
 #'   Size of the slice in each axis. Must have length equal to
 #'   `naxes(x)` and satisfy `1 <= slice_sizes <= nv_shape(x)`
@@ -554,7 +594,7 @@ prim_static_slice <- new_primitive(
 prim_dynamic_slice <- new_primitive(
   "dynamic_slice",
   function(x, ..., slice_sizes) {
-    start_indices <- list(...)
+    start_indices <- promote_start_indices(list(...))
     infer_fn <- function(x, ..., slice_sizes) {
       start_indices_avals <- list(...)
       for (i in seq_along(start_indices_avals)) {
@@ -573,8 +613,9 @@ prim_dynamic_slice <- new_primitive(
       infer_fn = infer_fn
     )[[1L]]
   },
-  # No promotion: `x` is the only array, and the start indices are integers
-  # whatever `x` is.
+  # `x` needs no promotion: it is the only operand of its kind. The start
+  # indices are promoted among themselves by `promote_start_indices()`, which
+  # is a group of their own -- they never take `x`'s data type.
   static = "slice_sizes"
 )
 
@@ -590,8 +631,8 @@ prim_dynamic_slice <- new_primitive(
 #'   data type and number of axes as `x`, with
 #'   `nv_shape(update) <= nv_shape(x)` per axis.
 #' @param ... ([`arrayish`] of integer type)\cr
-#'   Scalar start indices, one per axis of `x`.
-#'   Each must be a scalar array.
+#'   Scalar start indices, one per axis of `x`. All must reach one integer
+#'   data type; see [prim_dynamic_slice()].
 #' @inheritSection prim_dynamic_slice Out Of Bounds Behavior
 #' @return [`arrayish`]\cr
 #'   Has the same data type and shape as `x`.
@@ -617,7 +658,7 @@ prim_dynamic_slice <- new_primitive(
 prim_dynamic_update_slice <- new_primitive(
   "dynamic_update_slice",
   function(x, update, ...) {
-    start_indices <- list(...)
+    start_indices <- promote_start_indices(list(...))
     infer_fn <- function(x, update, ...) {
       start_indices_avals <- list(...)
       for (i in seq_along(start_indices_avals)) {
@@ -2856,7 +2897,8 @@ prim_rng_bit_generator <- new_primitive(
 #' @param x ([`arrayish`])\cr
 #'   Arrayish value of any data type. The base array to scatter into.
 #' @param scatter_indices ([`arrayish`] of integer type)\cr
-#'   Array of indices. Contains index vectors that map to positions in
+#'   Array of indices; must have an integer data type, and never takes `x`'s.
+#'   Contains index vectors that map to positions in
 #'   `x` via `scatter_axes_to_x_axes`. The axis specified
 #'   by `index_vector_axis` holds the index vectors.
 #' @param update ([`arrayish`])\cr
@@ -2944,6 +2986,7 @@ prim_scatter <- new_primitive(
     force(x)
     force(scatter_indices)
     force(update)
+    assert_index_dtype(scatter_indices, "scatter_indices")
     # Settled before `peek_dtype(x)` below builds the update computation's
     # parameter slots. `scatter_indices` keeps out of it: it is an index array,
     # not an operand `x` and `update` have to agree with.
@@ -3056,9 +3099,10 @@ prim_scatter <- new_primitive(
 #' given indices.
 #' @template param_prim_x_any
 #' @param start_indices ([`arrayish`] of integer type)\cr
-#'   Array of starting indices. Contains index vectors that map to
-#'   positions in `x` via `start_index_map`. The axis
-#'   specified by `index_vector_axis` holds the index vectors.
+#'   Array of starting indices; must have an integer data type, and never takes
+#'   `x`'s. Contains index vectors that map to positions in `x` via
+#'   `start_index_map`. The axis specified by `index_vector_axis` holds the
+#'   index vectors.
 #' @param slice_sizes (`integer()`)\cr
 #'   Size of the slice to gather from `x` in each axis.
 #'   Must have length equal to `naxes(x)`.
@@ -3137,6 +3181,7 @@ prim_gather <- new_primitive(
     indices_are_sorted = FALSE,
     unique_indices = FALSE
   ) {
+    assert_index_dtype(start_indices, "start_indices")
     infer_fn <- function(
       x,
       start_indices,
@@ -3192,8 +3237,9 @@ prim_gather <- new_primitive(
       infer_fn = infer_fn
     )[[1L]]
   },
-  # No promotion: `x` is the only array, and the start indices are integers
-  # whatever `x` is.
+  # `x` and `start_indices` are operands of different kinds and never meet at
+  # one data type, so there is nothing for a promotion rule to do; the indices
+  # are only checked for being integers.
   static = 3:11
 )
 

--- a/man/prim_dynamic_slice.Rd
+++ b/man/prim_dynamic_slice.Rd
@@ -11,8 +11,10 @@ prim_dynamic_slice(x, ..., slice_sizes)
 Arrayish value of any data type.}
 
 \item{...}{(\code{\link{arrayish}} of integer type)\cr
-Scalar start indices, one per axis. Each must be a
-scalar array. Pass one scalar per axis of \code{x}.}
+Scalar start indices, one per axis of \code{x}. All must reach one integer
+data type: an R value is written as an integer (\code{1L}) and takes the data
+type of the indices it meets, and indices that already have one must
+agree. They never take \code{x}'s data type.}
 
 \item{slice_sizes}{(\code{integer()})\cr
 Size of the slice in each axis. Must have length equal to

--- a/man/prim_dynamic_slice.Rd
+++ b/man/prim_dynamic_slice.Rd
@@ -11,10 +11,8 @@ prim_dynamic_slice(x, ..., slice_sizes)
 Arrayish value of any data type.}
 
 \item{...}{(\code{\link{arrayish}} of integer type)\cr
-Scalar start indices, one per axis of \code{x}. All must reach one integer
-data type: an R value is written as an integer (\code{1L}) and takes the data
-type of the indices it meets, and indices that already have one must
-agree. They never take \code{x}'s data type.}
+Scalar start indices, one per axis of \code{x}.
+Must all have the same integer data type, which R values are materialized at.}
 
 \item{slice_sizes}{(\code{integer()})\cr
 Size of the slice in each axis. Must have length equal to

--- a/man/prim_dynamic_update_slice.Rd
+++ b/man/prim_dynamic_update_slice.Rd
@@ -16,8 +16,8 @@ data type and number of axes as \code{x}, with
 \code{nv_shape(update) <= nv_shape(x)} per axis.}
 
 \item{...}{(\code{\link{arrayish}} of integer type)\cr
-Scalar start indices, one per axis of \code{x}.
-Each must be a scalar array.}
+Scalar start indices, one per axis of \code{x}. All must reach one integer
+data type; see \code{\link[=prim_dynamic_slice]{prim_dynamic_slice()}}.}
 }
 \value{
 \code{\link{arrayish}}\cr

--- a/man/prim_gather.Rd
+++ b/man/prim_gather.Rd
@@ -23,9 +23,10 @@ prim_gather(
 Arrayish value of any data type.}
 
 \item{start_indices}{(\code{\link{arrayish}} of integer type)\cr
-Array of starting indices. Contains index vectors that map to
-positions in \code{x} via \code{start_index_map}. The axis
-specified by \code{index_vector_axis} holds the index vectors.}
+Array of starting indices; must have an integer data type, and never takes
+\code{x}'s. Contains index vectors that map to positions in \code{x} via
+\code{start_index_map}. The axis specified by \code{index_vector_axis} holds the
+index vectors.}
 
 \item{slice_sizes}{(\code{integer()})\cr
 Size of the slice to gather from \code{x} in each axis.

--- a/man/prim_scatter.Rd
+++ b/man/prim_scatter.Rd
@@ -24,7 +24,8 @@ prim_scatter(
 Arrayish value of any data type. The base array to scatter into.}
 
 \item{scatter_indices}{(\code{\link{arrayish}} of integer type)\cr
-Array of indices. Contains index vectors that map to positions in
+Array of indices; must have an integer data type, and never takes \code{x}'s.
+Contains index vectors that map to positions in
 \code{x} via \code{scatter_axes_to_x_axes}. The axis specified
 by \code{index_vector_axis} holds the index vectors.}
 

--- a/tests/testthat/test-api-subset.R
+++ b/tests/testthat/test-api-subset.R
@@ -421,3 +421,9 @@ describe("subset_specs_start_indices", {
     expect_equal(x, nv_array(2:11))
   })
 })
+
+test_that("nv_subset still selects with an integer index vector", {
+  # Regression guard for the index data type checks the slicing primitives gained.
+  x <- nv_array(c(1, 2, 3, 4, 5), dtype = "f64")
+  expect_equal(as.numeric(nv_subset(x, 2:3)), c(2, 3))
+})

--- a/tests/testthat/test-primitives-stablehlo.R
+++ b/tests/testthat/test-primitives-stablehlo.R
@@ -1214,3 +1214,88 @@ test_that("nv_matmul exposes precision and defaults to highest", {
 if (nzchar(system.file(package = "torch"))) {
   source(system.file("extra-tests", "test-primitives-stablehlo-torch.R", package = "anvl"), local = TRUE)
 }
+
+describe("index operands of the slicing primitives", {
+  x <- nv_array(c(1, 2, 3, 4, 5), dtype = "f64")
+  m <- nv_array(1:6, shape = c(2, 3))
+
+  it("brings a dynamic slice's start indices to one data type", {
+    # StableHLO requires all start indices to share an element type, so the
+    # bare `1L` has to yield to its `i64` sibling rather than take its default.
+    expect_equal(
+      as.numeric(prim_dynamic_slice(m, nv_scalar(1L, "i64"), 1L, slice_sizes = c(1L, 2L))),
+      c(1, 3)
+    )
+    expect_equal(as.numeric(prim_dynamic_slice(x, 2L, slice_sizes = 2L)), c(2, 3))
+    expect_equal(as.numeric(prim_dynamic_slice(x, nv_scalar(2L, "i64"), slice_sizes = 2L)), c(2, 3))
+  })
+
+  it("names the start index whose data type cannot be reached", {
+    expect_error(
+      prim_dynamic_update_slice(m, nv_array(1L, shape = c(1, 1)), nv_scalar(1L, "i64"), nv_scalar(1L, "i32")),
+      "`start index 1` is `i64` and `start index 2` is `i32`"
+    )
+  })
+
+  it("rejects a non-integer index instead of failing in the lowering", {
+    expect_error(prim_dynamic_slice(x, 1, slice_sizes = 2L), "`start index 1` must be an index of integer data type")
+    expect_error(prim_dynamic_slice(x, 1, slice_sizes = 2L), "Write it as an R integer")
+    expect_error(
+      prim_dynamic_update_slice(x, nv_array(9, dtype = "f64"), 1),
+      "`start index 1` must be an index of integer data type"
+    )
+    expect_error(
+      jit(function(x) prim_dynamic_slice(x, 1, slice_sizes = 2L))(x),
+      "must be an index of integer data type"
+    )
+  })
+
+  it("rejects non-integer gather and scatter indices", {
+    expect_error(
+      prim_gather(
+        nv_array(1:9, shape = c(3, 3)),
+        matrix(c(1, 3), ncol = 1),
+        slice_sizes = c(1L, 3L),
+        offset_axes = 2L,
+        collapsed_slice_axes = 1L,
+        x_batching_axes = integer(0),
+        start_indices_batching_axes = integer(0),
+        start_index_map = 1L,
+        index_vector_axis = 2L
+      ),
+      "`start_indices` must be an index of integer data type"
+    )
+    expect_error(
+      prim_scatter(
+        nv_array(c(0, 0, 0)),
+        matrix(c(1, 3), ncol = 1),
+        nv_array(c(10, 30)),
+        update_window_axes = integer(0),
+        inserted_window_axes = 1L,
+        x_batching_axes = integer(0),
+        scatter_indices_batching_axes = integer(0),
+        scatter_axes_to_x_axes = 1L,
+        index_vector_axis = 2L
+      ),
+      "`scatter_indices` must be an index of integer data type"
+    )
+  })
+
+  it("still accepts indices that are integers", {
+    expect_equal(
+      as.numeric(prim_scatter(
+        nv_array(c(0, 0, 0)),
+        nv_array(matrix(c(1L, 3L), ncol = 1)),
+        nv_array(c(10, 30)),
+        update_window_axes = integer(0),
+        inserted_window_axes = 1L,
+        x_batching_axes = integer(0),
+        scatter_indices_batching_axes = integer(0),
+        scatter_axes_to_x_axes = 1L,
+        index_vector_axis = 2L
+      )),
+      c(10, 0, 30)
+    )
+    expect_equal(as.numeric(nv_subset(x, 2:3)), c(2, 3))
+  })
+})

--- a/tests/testthat/test-primitives-stablehlo.R
+++ b/tests/testthat/test-primitives-stablehlo.R
@@ -1215,11 +1215,11 @@ if (nzchar(system.file(package = "torch"))) {
   source(system.file("extra-tests", "test-primitives-stablehlo-torch.R", package = "anvl"), local = TRUE)
 }
 
-describe("index operands of the slicing primitives", {
+describe("prim_dynamic_slice", {
   x <- nv_array(c(1, 2, 3, 4, 5), dtype = "f64")
   m <- nv_array(1:6, shape = c(2, 3))
 
-  it("brings a dynamic slice's start indices to one data type", {
+  it("brings its start indices to one data type", {
     # StableHLO requires all start indices to share an element type, so the
     # bare `1L` has to yield to its `i64` sibling rather than take its default.
     expect_equal(
@@ -1230,6 +1230,20 @@ describe("index operands of the slicing primitives", {
     expect_equal(as.numeric(prim_dynamic_slice(x, nv_scalar(2L, "i64"), slice_sizes = 2L)), c(2, 3))
   })
 
+  it("rejects a non-integer index instead of failing in the lowering", {
+    expect_error(prim_dynamic_slice(x, 1, slice_sizes = 2L), "`start index 1` must be an index of integer data type")
+    expect_error(prim_dynamic_slice(x, 1, slice_sizes = 2L), "Write it as an R integer")
+    expect_error(
+      jit(function(x) prim_dynamic_slice(x, 1, slice_sizes = 2L))(x),
+      "must be an index of integer data type"
+    )
+  })
+})
+
+describe("prim_dynamic_update_slice", {
+  x <- nv_array(c(1, 2, 3, 4, 5), dtype = "f64")
+  m <- nv_array(1:6, shape = c(2, 3))
+
   it("names the start index whose data type cannot be reached", {
     expect_error(
       prim_dynamic_update_slice(m, nv_array(1L, shape = c(1, 1)), nv_scalar(1L, "i64"), nv_scalar(1L, "i32")),
@@ -1238,64 +1252,61 @@ describe("index operands of the slicing primitives", {
   })
 
   it("rejects a non-integer index instead of failing in the lowering", {
-    expect_error(prim_dynamic_slice(x, 1, slice_sizes = 2L), "`start index 1` must be an index of integer data type")
-    expect_error(prim_dynamic_slice(x, 1, slice_sizes = 2L), "Write it as an R integer")
     expect_error(
       prim_dynamic_update_slice(x, nv_array(9, dtype = "f64"), 1),
       "`start index 1` must be an index of integer data type"
     )
-    expect_error(
-      jit(function(x) prim_dynamic_slice(x, 1, slice_sizes = 2L))(x),
-      "must be an index of integer data type"
-    )
   })
 
-  it("rejects non-integer gather and scatter indices", {
-    expect_error(
-      prim_gather(
-        nv_array(1:9, shape = c(3, 3)),
-        matrix(c(1, 3), ncol = 1),
-        slice_sizes = c(1L, 3L),
-        offset_axes = 2L,
-        collapsed_slice_axes = 1L,
-        x_batching_axes = integer(0),
-        start_indices_batching_axes = integer(0),
-        start_index_map = 1L,
-        index_vector_axis = 2L
-      ),
-      "`start_indices` must be an index of integer data type"
+  it("still writes at an integer index", {
+    expect_equal(as.numeric(prim_dynamic_update_slice(x, nv_array(9, dtype = "f64"), 2L)), c(1, 9, 3, 4, 5))
+  })
+})
+
+describe("prim_gather", {
+  gather_at <- function(indices) {
+    prim_gather(
+      nv_array(1:9, shape = c(3, 3)),
+      indices,
+      slice_sizes = c(1L, 3L),
+      offset_axes = 2L,
+      collapsed_slice_axes = 1L,
+      x_batching_axes = integer(0),
+      start_indices_batching_axes = integer(0),
+      start_index_map = 1L,
+      index_vector_axis = 2L
     )
-    expect_error(
-      prim_scatter(
-        nv_array(c(0, 0, 0)),
-        matrix(c(1, 3), ncol = 1),
-        nv_array(c(10, 30)),
-        update_window_axes = integer(0),
-        inserted_window_axes = 1L,
-        x_batching_axes = integer(0),
-        scatter_indices_batching_axes = integer(0),
-        scatter_axes_to_x_axes = 1L,
-        index_vector_axis = 2L
-      ),
-      "`scatter_indices` must be an index of integer data type"
-    )
+  }
+
+  it("rejects non-integer start indices", {
+    expect_error(gather_at(matrix(c(1, 3), ncol = 1)), "`start_indices` must be an index of integer data type")
   })
 
-  it("still accepts indices that are integers", {
-    expect_equal(
-      as.numeric(prim_scatter(
-        nv_array(c(0, 0, 0)),
-        nv_array(matrix(c(1L, 3L), ncol = 1)),
-        nv_array(c(10, 30)),
-        update_window_axes = integer(0),
-        inserted_window_axes = 1L,
-        x_batching_axes = integer(0),
-        scatter_indices_batching_axes = integer(0),
-        scatter_axes_to_x_axes = 1L,
-        index_vector_axis = 2L
-      )),
-      c(10, 0, 30)
+  it("still gathers at integer indices", {
+    expect_equal(as.numeric(gather_at(nv_array(matrix(c(1L, 3L), ncol = 1)))[1, ]), c(1, 4, 7))
+  })
+})
+
+describe("prim_scatter", {
+  scatter_at <- function(indices) {
+    prim_scatter(
+      nv_array(c(0, 0, 0)),
+      indices,
+      nv_array(c(10, 30)),
+      update_window_axes = integer(0),
+      inserted_window_axes = 1L,
+      x_batching_axes = integer(0),
+      scatter_indices_batching_axes = integer(0),
+      scatter_axes_to_x_axes = 1L,
+      index_vector_axis = 2L
     )
-    expect_equal(as.numeric(nv_subset(x, 2:3)), c(2, 3))
+  }
+
+  it("rejects non-integer scatter indices", {
+    expect_error(scatter_at(matrix(c(1, 3), ncol = 1)), "`scatter_indices` must be an index of integer data type")
+  })
+
+  it("still scatters at integer indices", {
+    expect_equal(as.numeric(scatter_at(nv_array(matrix(c(1L, 3L), ncol = 1)))), c(10, 0, 30))
   })
 })


### PR DESCRIPTION
Index operands were the one place the type system did not reach. Two consequences, both ending in a raw MLIR message that names an operand number rather than an argument:

* `prim_dynamic_slice()` and `prim_dynamic_update_slice()` never brought their variadic start indices to a common data type, though StableHLO requires them to share one. `prim_dynamic_slice(m, nv_scalar(1L, "i64"), 1L, ...)` failed with `start indices must have same element type` where the bare `1L` should simply have yielded.
* A bare R double reaching any index operand committed to its `f32` default and blew up in the backend.

`promote_start_indices()` now checks each index is an integer -- while it is still an R value, so the message can say to write `1L` -- and then promotes them among themselves as their own group, never against `x`. `prim_gather()` and `prim_scatter()` gain the same check on their single index array.

The comments claiming "`x` is the only array" on `prim_dynamic_slice()` and `prim_gather()` were wrong on both halves and are replaced.


Claude-Session: https://claude.ai/code/session_01NCxqfqAhCCd17ygJeJm8YA