### PR TITLE
Zero the gradient of a conversion into a non-float data type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,15 @@
   functions was improved.
 * `jit_eval()` was removed as it is no longer needed.
 
+## Bug fixes
+
+* The gradient of a conversion into a non-float data type is now zero instead
+  of one. `prim_convert()` / `nv_convert()` passed the cotangent through
+  whatever the data types were, so `nv_convert(nv_convert(x, "i32"), "f64")`
+  reported a gradient of 1 where `nv_floor()` -- the same function on the
+  reals -- correctly reported 0. Conversions between floats still pass the
+  gradient through.
+
 ## Tests
 
 * Moved some of pjrt's dispatcher tests into anvl.

--- a/R/rules-reverse.R
+++ b/R/rules-reverse.R
@@ -556,11 +556,19 @@ prim_if[["reverse"]] <- rule_reverse(function(inputs, outputs, grads, params, re
 
 # convert reverse -----------------
 
+# A conversion is the identity, and so passes the cotangent through, only
+# between floats. Landing on an integer or a bool is a step function whose
+# derivative is zero almost everywhere, and a value that started as one has no
+# gradient to give back either. Passing the cotangent through regardless would
+# report a gradient of 1 across `nv_convert(nv_convert(x, "i32"), "f64")`,
+# where `prim_floor()` -- the same function on the reals -- correctly reports 0.
 prim_convert[["reverse"]] <- rule_reverse(function(inputs, outputs, grads, params, required) {
   x <- inputs[[1L]]
-  grad <- grads[[1L]]
+  differentiable <- is_dtype_float(dtype(x)) && is_dtype_float(dtype(outputs[[1L]]))
   list(
-    if (required[[1L]]) prim_convert(grad, dtype(x))
+    if (required[[1L]]) {
+      if (differentiable) prim_convert(grads[[1L]], dtype(x)) else prim_fill(0L, dtype = dtype(x), shape = shape(x))
+    }
   )
 })
 

--- a/tests/testthat/test-primitives-reverse.R
+++ b/tests/testthat/test-primitives-reverse.R
@@ -358,6 +358,38 @@ test_that("prim_convert reverse converts gradients to the input dtype", {
   expect_equal(dtype(grads[[1L]]), as_dtype("f32"))
 })
 
+test_that("prim_convert reverse is zero across a non-float data type", {
+  # `float(int(x))` is a staircase: its derivative is zero almost everywhere,
+  # the same answer `prim_floor()` gives for the same function on the reals.
+  x <- nv_array(c(1.5, 2.5, 3.5), dtype = "f64")
+  through_int <- jit(gradient(function(x) {
+    nv_reduce_sum(prim_convert(prim_convert(x, "i32"), "f64"))
+  }))
+  through_bool <- jit(gradient(function(x) {
+    nv_reduce_sum(prim_convert(prim_convert(x, "bool"), "f64"))
+  }))
+  floor_ref <- jit(gradient(function(x) nv_reduce_sum(prim_floor(x))))
+
+  expect_equal(as.numeric(through_int(x)[[1L]]), c(0, 0, 0))
+  expect_equal(as.numeric(through_bool(x)[[1L]]), c(0, 0, 0))
+  expect_equal(as.numeric(through_int(x)[[1L]]), as.numeric(floor_ref(x)[[1L]]))
+})
+
+test_that("prim_convert reverse passes the gradient through between floats", {
+  x <- nv_array(c(1.5, 2.5, 3.5), dtype = "f64")
+  f <- jit(gradient(function(x) nv_reduce_sum(prim_convert(prim_convert(x, "f32"), "f64"))))
+  expect_equal(as.numeric(f(x)[[1L]]), c(1, 1, 1))
+  expect_equal(dtype(f(x)[[1L]]), as_dtype("f64"))
+})
+
+test_that("prim_convert reverse leaves the rest of an expression differentiable", {
+  x <- nv_array(c(1.5, 2.5, 3.5), dtype = "f64")
+  f <- jit(gradient(function(x) {
+    nv_reduce_sum(x * nv_scalar(2, "f64") + nv_convert(nv_convert(x, "i32"), "f64"))
+  }))
+  expect_equal(as.numeric(f(x)[[1L]]), c(2, 2, 2))
+})
+
 test_that("prim_eq, prim_ne, prim_gt, prim_ge, prim_lt, prim_le", {
   a <- 1
   b <- 2

--- a/tests/testthat/test-promotion.R
+++ b/tests/testthat/test-promotion.R
@@ -25,17 +25,6 @@ test_that("a value that has committed keeps its dtype", {
   )
 })
 
-test_that("prim_convert reverse", {
-  out <- jit(function(x) {
-    z <- prim_convert(x, "f32")
-    a <- gradient(\(y) {
-      y_int <- prim_convert(y, "i32")
-      prim_convert(y_int, "f32")
-    })(z)[[1L]]
-  })(nv_scalar(TRUE))
-  expect_equal(out, nv_scalar(1, dtype = "f32"))
-})
-
 test_that("prim_if outputs keep the dtype of their branches", {
   f <- function(pred, x) {
     x <- x * 2L


### PR DESCRIPTION
`prim_convert[["reverse"]]` passed the cotangent through unconditionally, so `nv_convert(nv_convert(x, "i32"), "f64")` reported a gradient of 1. That expression is a staircase; its derivative is zero almost everywhere, which is what `prim_floor()` -- the same function on the reals -- already reported, and what JAX reports here.

The rule now passes the cotangent through only when the operand and the result are both floats, and otherwise returns a zero at the operand's data type, matching `reverse_zero_uni()` and the existing `prim_bitcast_convert()` rule.

The old behaviour was asserted by `test_that("prim_convert reverse")` in test-promotion.R, which had carried the value through several refactors with no stated rationale. It is replaced by tests next to the rule it covers, in test-primitives-reverse.R.


Claude-Session: https://claude.ai/code/session_01NCxqfqAhCCd17ygJeJm8YA