### PR TITLE
Check prim_fill's value against the data type it is built at

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,16 @@
   functions was improved.
 * `jit_eval()` was removed as it is no longer needed.
 
+## Bug fixes
+
+* `prim_fill()` / `nv_fill()` now check that `value` is something `dtype` can
+  hold, instead of letting it reach the backend. `prim_fill(TRUE, dtype =
+  "f32")` produced a PJRT buffer-aliasing error and now fills with `1`;
+  `prim_fill(-1L, dtype = "ui32")` and `prim_fill(300L, dtype = "i8")` produced
+  raw MLIR errors and are now refused by name; `prim_fill(1.5, dtype = "i32")`
+  truncated silently; and a `value` of length greater than one was silently
+  recycled although it is documented as a scalar.
+
 ## Tests
 
 * Moved some of pjrt's dispatcher tests into anvl.

--- a/R/primitives.R
+++ b/R/primitives.R
@@ -26,6 +26,74 @@ make_unary_op <- function(stablehlo_infer) {
 }
 
 
+# `value` is a literal the caller pins to `dtype`: `prim_fill()` is a
+# constructor, so naming a data type outside the value's own category is the
+# point here (`prim_fill(1, dtype = "i32")`), unlike promotion. What it must
+# not do is reach the backend as something `dtype` cannot represent -- the
+# constant is then emitted at the R value's own storage type and the program
+# fails at execute time with a buffer-aliasing error, or MLIR refuses to parse
+# it. Bringing the value to the target's storage type here settles both.
+resolve_fill_value <- function(value, dtype) {
+  ok <- (is.numeric(value) || is.logical(value)) &&
+    length(value) == 1L &&
+    (!is.na(value) || is.nan(value))
+  if (!ok) {
+    cli_abort(
+      c(
+        "{.arg value} must be a single non-missing number or logical.",
+        x = "Got {.obj_type_friendly {value}} of length {length(value)}."
+      ),
+      call = NULL
+    )
+  }
+  if (is_dtype_bool(dtype)) {
+    return(as.logical(value))
+  }
+  value <- as.double(value)
+  if (is_dtype_float(dtype)) {
+    return(value)
+  }
+  target <- as.character(dtype)
+  if (!is.finite(value)) {
+    cli_abort(
+      c(
+        "{.arg value} must be finite at data type {.val {target}}.",
+        x = "Got {.val {value}}."
+      ),
+      call = NULL
+    )
+  }
+  if (value != trunc(value)) {
+    cli_abort(
+      c(
+        "{.arg value} must be a whole number at data type {.val {target}}.",
+        x = "Got {.val {value}}.",
+        i = "Round it first, or build the array at a float data type."
+      ),
+      call = NULL
+    )
+  }
+  limits <- dtype_limits(dtype)
+  if (value < limits[[1L]] || value > limits[[2L]]) {
+    cli_abort(
+      c(
+        "{.arg value} is out of range for data type {.val {target}}.",
+        x = "Got {.val {value}}, but {.val {target}} holds {limits[[1L]]} to {limits[[2L]]}."
+      ),
+      call = NULL
+    )
+  }
+  value
+}
+
+dtype_limits <- function(dtype) {
+  width <- dtype_width(dtype)
+  if (is_dtype_uint(dtype)) {
+    return(c(0, 2^width - 1))
+  }
+  c(-2^(width - 1L), 2^(width - 1L) - 1)
+}
+
 infer_reduce <- function(x, axes, drop) {
   old_shape <- shape(x)
   if (drop) {
@@ -61,8 +129,11 @@ infer_reduce_boolean <- function(x, axes, drop) {
 #' `nv_array(1, shape = c(100, 100))` is that lowering of [prim_fill()] is
 #' efficiently represented in the compiled program, while the latter uses
 #' 100 * 100 * 4 bytes of memory.
-#' @param value (`numeric(1)`)\cr
-#'   Scalar value to fill the array with.
+#' @param value (`numeric(1)` | `logical(1)`)\cr
+#'   Scalar value to fill the array with. It is built at `dtype`, whatever its
+#'   own category -- `prim_fill(1, dtype = "i32")` is an integer array -- but
+#'   it must be something `dtype` can hold: a whole number in range for an
+#'   integer data type, and any number for a float one.
 #' @param shape (`integer()`)\cr
 #'   Shape of the output array.
 #' @template param_dtype
@@ -80,6 +151,7 @@ infer_reduce_boolean <- function(x, axes, drop) {
 prim_fill <- new_primitive(
   "fill",
   function(value, shape, dtype, device = NULL) {
+    value <- resolve_fill_value(value, as_dtype(dtype))
     infer_fill <- function(value, shape, dtype) {
       list(AbstractArray(dtype = as_dtype(dtype), shape = shape))
     }

--- a/man/prim_fill.Rd
+++ b/man/prim_fill.Rd
@@ -7,8 +7,11 @@
 prim_fill(value, shape, dtype, device = NULL)
 }
 \arguments{
-\item{value}{(\code{numeric(1)})\cr
-Scalar value to fill the array with.}
+\item{value}{(\code{numeric(1)} | \code{logical(1)})\cr
+Scalar value to fill the array with. It is built at \code{dtype}, whatever its
+own category -- \code{prim_fill(1, dtype = "i32")} is an integer array -- but
+it must be something \code{dtype} can hold: a whole number in range for an
+integer data type, and any number for a float one.}
 
 \item{shape}{(\code{integer()})\cr
 Shape of the output array.}

--- a/tests/testthat/test-primitives-stablehlo.R
+++ b/tests/testthat/test-primitives-stablehlo.R
@@ -1214,3 +1214,33 @@ test_that("nv_matmul exposes precision and defaults to highest", {
 if (nzchar(system.file(package = "torch"))) {
   source(system.file("extra-tests", "test-primitives-stablehlo-torch.R", package = "anvl"), local = TRUE)
 }
+
+describe("prim_fill value", {
+  it("builds the value at the requested data type across categories", {
+    # `prim_fill()` is a constructor: naming a data type outside the value's
+    # own category is the point, unlike promotion.
+    expect_equal(as.numeric(prim_fill(0L, shape = 2L, dtype = "f32")), c(0, 0))
+    expect_equal(as.numeric(prim_fill(TRUE, shape = 2L, dtype = "f32")), c(1, 1))
+    expect_equal(as.numeric(prim_fill(1, shape = 2L, dtype = "i32")), c(1, 1))
+    expect_equal(as.logical(prim_fill(TRUE, shape = 2L, dtype = "bool")), c(TRUE, TRUE))
+  })
+
+  it("keeps the float specials", {
+    expect_true(all(is.nan(as.numeric(prim_fill(NaN, shape = 2L, dtype = "f32")))))
+    expect_equal(as.numeric(prim_fill(Inf, shape = 2L, dtype = "f32")), c(Inf, Inf))
+  })
+
+  it("rejects a value the data type cannot hold", {
+    expect_error(prim_fill(1.5, shape = 2L, dtype = "i32"), "must be a whole number")
+    expect_error(prim_fill(-1L, shape = 2L, dtype = "ui32"), "out of range")
+    expect_error(prim_fill(300L, shape = 2L, dtype = "i8"), "out of range")
+    expect_error(prim_fill(Inf, shape = 2L, dtype = "i32"), "must be finite")
+    expect_equal(as.numeric(prim_fill(255L, shape = 2L, dtype = "ui8")), c(255, 255))
+  })
+
+  it("rejects a value that is not a single number", {
+    expect_error(prim_fill(c(1, 2), shape = 4L, dtype = "f32"), "must be a single non-missing")
+    expect_error(prim_fill(NA, shape = 2L, dtype = "f32"), "must be a single non-missing")
+    expect_error(prim_fill("a", shape = 2L, dtype = "f32"), "must be a single non-missing")
+  })
+})


### PR DESCRIPTION
`value` is a static parameter, so no promotion rule ever looked at it and nothing stood between an R literal and the constant emitted for it. Four symptoms, all reproducible:

* `prim_fill(TRUE, dtype = "f32")` emitted a boolean constant behind an `f32` declaration and failed at execute time with `Expected aliased input 0 ... to have the same size`.
* `prim_fill(-1L, dtype = "ui32")` and `prim_fill(300L, dtype = "i8")` produced raw MLIR parse errors.
* `prim_fill(1.5, dtype = "i32")` truncated silently, where `nv_convert()` warns for the same narrowing.
* A `value` longer than one was silently recycled, though it is documented as a scalar.

`resolve_fill_value()` brings the literal to the target's storage type and refuses what the target cannot hold. Crossing a type category stays allowed -- `prim_fill()` is a constructor, and the caller names the data type -- which is what the reverse rules rely on when they build cotangents with `prim_fill(1, dtype = dtype(x))`.


Claude-Session: https://claude.ai/code/session_01NCxqfqAhCCd17ygJeJm8YA