### PR TITLE
Reject a non-boolean input to reduce_any / reduce_all

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,14 @@
   functions was improved.
 * `jit_eval()` was removed as it is no longer needed.
 
+## Bug fixes
+
+* `prim_reduce_any()` / `prim_reduce_all()` (and `nv_reduce_any()` /
+  `nv_reduce_all()`) now reject a non-boolean input when the call is traced.
+  Type inference declared a `bool` output whatever the input was, so an
+  integer operand reached the lowering and failed with `Data types of inputs
+  and init_values must match`.
+
 ## Tests
 
 * Moved some of pjrt's dispatcher tests into anvl.

--- a/R/primitives.R
+++ b/R/primitives.R
@@ -41,6 +41,20 @@ infer_reduce <- function(x, axes, drop) {
 }
 
 infer_reduce_boolean <- function(x, axes, drop) {
+  # The output is a `bool` whatever the input is, but the lowering reduces with
+  # `or` / `and` over an init value built at `bool`, so a non-boolean operand
+  # fails there with `Data types of inputs and init_values must match`. Say so
+  # here instead, where the argument still has a name.
+  if (!is_dtype_bool(dtype(x))) {
+    cli_abort(
+      c(
+        "{.arg x} must have a boolean data type.",
+        x = "Got {.val {as.character(dtype(x))}}.",
+        i = "Compare it first, e.g. {.code x != 0L}, or convert it with {.fn nv_convert}."
+      ),
+      call = NULL
+    )
+  }
   old_shape <- shape(x)
   if (drop) {
     new_shape <- old_shape[-axes]

--- a/tests/testthat/test-primitives-stablehlo.R
+++ b/tests/testthat/test-primitives-stablehlo.R
@@ -1214,3 +1214,21 @@ test_that("nv_matmul exposes precision and defaults to highest", {
 if (nzchar(system.file(package = "torch"))) {
   source(system.file("extra-tests", "test-primitives-stablehlo-torch.R", package = "anvl"), local = TRUE)
 }
+
+describe("prim_reduce_any / prim_reduce_all input data type", {
+  it("reduces a boolean array", {
+    b <- nv_array(c(TRUE, FALSE, TRUE))
+    expect_true(as_array(prim_reduce_any(b, 1L)))
+    expect_false(as_array(prim_reduce_all(b, 1L)))
+  })
+
+  it("rejects a non-boolean input at trace time", {
+    # The declared output is `bool` whatever the input is, so nothing used to
+    # stop a non-boolean operand before the lowering.
+    i <- nv_array(c(1L, 0L, 3L))
+    expect_error(prim_reduce_any(i, 1L), "`x` must have a boolean data type")
+    expect_error(prim_reduce_all(i, 1L), "`x` must have a boolean data type")
+    expect_error(nv_reduce_any(i), "`x` must have a boolean data type")
+    expect_error(nv_reduce_any(nv_array(c(1, 0))), "Got \"f32\"")
+  })
+})


### PR DESCRIPTION
`infer_reduce_boolean()` hard-coded a `bool` output whatever the operand was, so nothing stopped an integer array at trace time. It reduces with `or` / `and` over an init value built at `bool`, and so failed in the lowering with `Data types of inputs and init_values must match` -- a message naming neither the argument nor the primitive.

The docs (`@template param_prim_x_boolean`) already said boolean; this makes the check match them.


Claude-Session: https://claude.ai/code/session_01NCxqfqAhCCd17ygJeJm8YA