### PR TITLE
Reject unsigned integers in prim_pow

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,13 @@
   functions was improved.
 * `jit_eval()` was removed as it is no longer needed.
 
+## Bug fixes
+
+* `prim_pow()` / `nv_pow()` now reject unsigned integer operands with an error
+  naming the data type, instead of failing in the backend with
+  `'math.ipowi' op operand #0 must be signless-integer-like`. XLA lowers an
+  integer power through an operation that takes signed integers only.
+
 ## Tests
 
 * Moved some of pjrt's dispatcher tests into anvl.

--- a/R/primitives.R
+++ b/R/primitives.R
@@ -4,15 +4,42 @@
 #' @include primitive.R
 #' @include jit.R
 
-make_binary_op <- function(stablehlo_infer) {
+# `check`, when given, is called with the promoted operands and rejects data
+# types the operation cannot take. It runs after promotion so it sees settled
+# data types, and before recording, so the error names the argument rather than
+# surfacing from the backend.
+make_binary_op <- function(stablehlo_infer, check = NULL) {
   force(stablehlo_infer)
+  force(check)
   infer_fn <- function(lhs, rhs) {
     list(vt2at(stablehlo_infer(at2vt(lhs), at2vt(rhs))[[1L]]))
   }
   function(lhs, rhs) {
     operands <- apply_promotion(list(lhs = lhs, rhs = rhs), promote_rdata_common())
+    if (!is.null(check)) {
+      check(operands)
+    }
     graph_desc_add(self, operands, infer_fn = infer_fn)[[1L]]
   }
+}
+
+# XLA lowers an integer `power` through `math.ipowi`, which takes signless
+# integers only. An unsigned operand passes StableHLO's own type inference --
+# the spec allows any integer type here -- and then fails in the backend with
+# `'math.ipowi' op operand #0 must be signless-integer-like`.
+assert_pow_dtype <- function(operands) {
+  dt <- peek_dtype(to_abstract(operands$lhs))
+  if (!is_dtype_uint(dt)) {
+    return(invisible(NULL))
+  }
+  cli_abort(
+    c(
+      "{.fn prim_pow} does not support unsigned integer data types.",
+      x = "Got {.val {as.character(dt)}}.",
+      i = "Convert to a signed integer or a float first, e.g. {.code nv_convert(x, \"i64\")}."
+    ),
+    call = NULL
+  )
 }
 
 make_unary_op <- function(stablehlo_infer) {
@@ -182,7 +209,11 @@ prim_div <- new_primitive("divide", make_binary_op(stablehlo::infer_types_divide
 #' @title Primitive Power
 #' @description
 #' Raises lhs to the power of rhs element-wise.
-#' @template params_prim_lhs_rhs_numeric
+#' @param lhs,rhs ([`arrayish`])\cr
+#'   Arrayish values of data type signed integer or floating-point.
+#'   Unsigned integers are not supported: XLA lowers an integer power through
+#'   an operation that takes signed integers only.
+#'   Must have the same shape.
 #' @template return_prim_binary
 #' @templateVar primitive_id power
 #' @template section_rules
@@ -194,7 +225,7 @@ prim_div <- new_primitive("divide", make_binary_op(stablehlo::infer_types_divide
 #' y <- nv_array(c(3, 2, 1))
 #' prim_pow(x, y)
 #' @export
-prim_pow <- new_primitive("power", make_binary_op(stablehlo::infer_types_power))
+prim_pow <- new_primitive("power", make_binary_op(stablehlo::infer_types_power, check = assert_pow_dtype))
 
 #' @title Primitive Broadcast
 #' @description

--- a/man/prim_pow.Rd
+++ b/man/prim_pow.Rd
@@ -8,7 +8,9 @@ prim_pow(lhs, rhs)
 }
 \arguments{
 \item{lhs, rhs}{(\code{\link{arrayish}})\cr
-Arrayish values of data type integer, unsigned integer, or floating-point.
+Arrayish values of data type signed integer or floating-point.
+Unsigned integers are not supported: XLA lowers an integer power through
+an operation that takes signed integers only.
 Must have the same shape.}
 }
 \value{

--- a/tests/testthat/test-primitives-stablehlo.R
+++ b/tests/testthat/test-primitives-stablehlo.R
@@ -1214,3 +1214,29 @@ test_that("nv_matmul exposes precision and defaults to highest", {
 if (nzchar(system.file(package = "torch"))) {
   source(system.file("extra-tests", "test-primitives-stablehlo-torch.R", package = "anvl"), local = TRUE)
 }
+
+describe("prim_pow data types", {
+  it("raises signed integers and floats", {
+    expect_equal(as.numeric(prim_pow(nv_array(c(2L, 3L)), nv_array(c(2L, 2L)))), c(4, 9))
+    expect_equal(as.numeric(prim_pow(nv_array(c(2, 3)), nv_array(c(2, 2)))), c(4, 9))
+  })
+
+  it("rejects unsigned integers instead of failing in the backend", {
+    # XLA lowers integer `power` through `math.ipowi`, which is signed-only.
+    expect_error(
+      prim_pow(nv_array(c(2L, 3L), dtype = "ui32"), nv_array(c(2L, 2L), dtype = "ui32")),
+      "does not support unsigned integer data types"
+    )
+    expect_error(
+      nv_pow(nv_array(c(2L, 3L), dtype = "ui8"), nv_array(c(2L, 2L), dtype = "ui8")),
+      "Got \"ui8\""
+    )
+  })
+
+  it("leaves the other unsigned binary operations alone", {
+    expect_equal(
+      as.numeric(prim_add(nv_array(c(2L, 3L), dtype = "ui32"), nv_array(c(1L, 1L), dtype = "ui32"))),
+      c(3, 4)
+    )
+  })
+})


### PR DESCRIPTION
XLA lowers an integer `power` through `math.ipowi`, which takes signless integers only, so an unsigned operand failed at compile time with `loc("wrapped_power_computation"): 'math.ipowi' op operand #0 must be signless-integer-like` -- a message that names neither the argument nor the primitive. StableHLO's own type inference accepts it, since the spec allows any integer type there, so the check has to be anvl's.

`make_binary_op()` gains an optional `check` run on the promoted operands, and the documentation no longer lists unsigned integers as supported. Signed integer and float powers, and every other unsigned binary operation, are unaffected.


Claude-Session: https://claude.ai/code/session_01NCxqfqAhCCd17ygJeJm8YA